### PR TITLE
Added signals for href and search properties of window.location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,38 @@ Hashes are usually of the form:
 #Biography
 ```
 
+- `href`
+
+```elm
+href : Signal String
+```
+
+This is a `Signal` of the entire url that changes whenever the url is modified, either by interaction or through code. Use this when you need access to the entire url.
+
+Hrefs are of the form:
+```
+http://www.website.com/morePath/myPath.html
+
+http://www.website.com/morePath/query?key1=val1&key2=val2
+```
+
+- `search`
+
+```elm
+search : Signal String
+```
+
+This is a `Signal` of the search string that changes whenever the url is modified, either by interaction or through code. Use this when you need access to the search string.
+
+Search strings are of the form:
+```
+?key=val
+
+?key1=val1&key2=val2
+
+?key1=val1&key2=val2&keyN=valN
+```
+
 - `length`
 
 ```elm

--- a/src/History.elm
+++ b/src/History.elm
@@ -8,7 +8,7 @@ module History where
 @docs back, forward, go
 
 # URL path as input
-@docs path, hash, length
+@docs path, hash, length, href, search
 
 -}
 
@@ -105,3 +105,27 @@ Paths are of the form: `/myPath.html` or `/users/4873/profile.html`
 -}
 path : Signal String
 path = Native.History.path
+
+{-| The current href (i.e., entire url value).  The value is updated
+whenever it is changed, either through interaction or code.
+Use this when you need access to the entire url.
+
+Hrefs are of the form: `http://www.website.com/morePath/myPath.html` or
+`http://www.website.com/morePath/query?key1=val1&key2=val2`.
+-}
+
+href : Signal String
+href = Native.History.href
+
+{-| The current search string (i.e., query string).  The value is 
+updated whenever the url changes, either through interaction
+or code.  Use this when you need access to the search query.
+
+Search strings are of the form:  `?key1=val1` or `?key1=val1&key2=val2`.
+-}
+
+search : Signal String
+search = Native.History.search
+
+
+

--- a/src/Native/History.js
+++ b/src/Native/History.js
@@ -19,13 +19,21 @@ Elm.Native.History.make = function(localRuntime){
 
   // length : Signal Int
   var length = NS.input('History.length', window.history.length);
+  
+  // search : Signal String
+  var search = NS.input('History.search', window.location.search);
 
+  // href : Signal String
+  var href = NS.input('History.href', window.location.href);
+  
   // hash : Signal String
   var hash = NS.input('History.hash', window.location.hash);
 
-  localRuntime.addListener([path.id, length.id], node, 'popstate', function getPath(event){
+  localRuntime.addListener([path.id, length.id, href.id, search.id], node, 'popstate', function getPath(event){
     localRuntime.notify(path.id, window.location.pathname);
     localRuntime.notify(length.id, window.history.length);
+    localRuntime.notify(href.id, window.location.href);
+    localRuntime.notify(search.id, window.location.search);
     localRuntime.notify(hash.id, window.location.hash);
   });
 
@@ -97,6 +105,8 @@ Elm.Native.History.make = function(localRuntime){
 
   return {
     path        : path,
+    search      : search,
+    href        : href,
     setPath     : setPath,
     replacePath : replacePath,
     go          : go,


### PR DESCRIPTION
As you know, elm-router doesn't yet support parameters or query strings.

Currently, I'm using elm-combine parser combinators to handle routing with parameters and query strings.  That requires, however, that I have access to the entire url.  So, I've added two signals:  `href` and `search`.  Obviously, they're just `location.href` and `location.search`.

The rationale for an `href` signal is that you can (if you like) simply throw away the origin part (via a parser) and then you have the `path` and `search` all in one signal.  The `search` signal is a convenience that may be used to avoid parsing in other situations.
